### PR TITLE
Potential fix for code scanning alert no. 1: Regular expression injection

### DIFF
--- a/pages/api/autocomplete.ts
+++ b/pages/api/autocomplete.ts
@@ -6,6 +6,7 @@ import {
 } from '../../types';
 import getMongoDb from '../../utils/mongodb';
 import { ObjectId } from 'mongodb';
+import _ from 'lodash';
 
 export default function handler(
   req: AutocompleteApiRequest,
@@ -14,8 +15,9 @@ export default function handler(
   const mongoDb = getMongoDb();
 
   const getTerms = async () => {
+    const safeTerm = _.escapeRegExp(req.body.term);
     const filter = {
-      sku: { $regex: new RegExp(`^${req.body.term}`) },
+      sku: { $regex: new RegExp(`^${safeTerm}`) },
       store_id: {
         $in: req.body.stores.map((store_id) => new ObjectId(store_id))
       }


### PR DESCRIPTION
Potential fix for [https://github.com/DrAndri/webstore-api/security/code-scanning/1](https://github.com/DrAndri/webstore-api/security/code-scanning/1)

The issue can be resolved by escaping all special regex characters in the user-supplied input before embedding it in the regular expression. The best and simplest method is to use a well-known escaping function, such as `_.escapeRegExp` from the `lodash` library. This converts any special regex characters in `req.body.term` to their escaped counterparts, making them literal instead of special, and thus preventing injection or DoS attacks.

Specifically, import `escapeRegExp` from lodash (or all of `_`, to match existing style if necessary) at the top of the file. Then, before constructing the regex, escape the term:  
```ts
const safeTerm = _.escapeRegExp(req.body.term);
```
And use:  
```ts
sku: { $regex: new RegExp(`^${safeTerm}`) }
```
in place of the vulnerable line.

This requires adding a new import and changing the relevant line in the filter object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
